### PR TITLE
Remove bundled css, because this app does not use stylesheet

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -19,9 +19,6 @@
             "matches": [
                 "https://github.com/*/*/pull/*"
             ],
-            "css": [
-                "styles/main.css"
-            ],
             "js": [
                 "bower_components/jQuery/dist/jquery.min.js",
                 "scripts/contentscript.js"


### PR DESCRIPTION
`grunt-contrib-cssmin` removes empty css file, so remove css file from package temporally.
[gruntjs - Write file even if output css is empty - Stack Overflow](http://stackoverflow.com/questions/23940940/write-file-even-if-output-css-is-empty)

Fixes #11 
