### PR TITLE
add support for github enterprise

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -20,7 +20,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://github.com/*/*/pull/*"
+                "https://*/*/*/pull/*"
             ],
             "js": [
                 "bower_components/jQuery/dist/jquery.js",

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -4,7 +4,7 @@
   var changeMergeButtonState = function() {
     var $container = $('#js-repo-pjax-container');
     var issueTitle = $container.find('.js-issue-title').text();
-    var $buttonMerge = $container.find('.merge-message button[data-details-container]');
+    var $buttonMerge = $container.find('.merge-message button[data-details-container], .merge-message .js-merge-branch-action');
     var disabled = false;
     var buttonHtml = '';
 


### PR DESCRIPTION
Hi, I'd like to use this in the company, but we are using github enterprise instead of Github.com, so I changed the match rule to work with github enterprise, and also github enterprise still use a legacy ui,  another selector is needed to pick up the merge button.