### PR TITLE
fix(permissions): drop storage

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -7,9 +7,7 @@
         "16": "images/icon2-16.png",
         "128": "images/icon2-128.png"
     },
-    "permissions": [
-      "storage"
-    ],
+    "permissions": [],
     "default_locale": "en",
     "background": {
         "scripts": [


### PR DESCRIPTION
for using `document.localStorage`, we don't need
storage permissions.

https://developer.chrome.com/docs/webstore/troubleshooting/#misunderstood-perms-storage

refs #333