### PR TITLE
chore(jshint): use highest es version in jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
   "node": true,
   "browser": true,
-  "esnext": true,
+  "esversion": 11,
   "bitwise": true,
   "camelcase": true,
   "curly": true,


### PR DESCRIPTION
use esversion 11 (ES 2020), latest version in jshint

refs #358 
refs #359 